### PR TITLE
MAID-2575: improve exception handling in JNI bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,41 @@
-sudo: false
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - RUST_STABLE=1.24.0
+    - PATH=$PATH:$HOME/.cargo/bin
+os:
+  - linux
+  - osx
 language: rust
 rust:
-    - stable
-    - beta
-    - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
+  - 1.24.0
+  - nightly-2018-02-05
+sudo: false
+branches:
+  only:
+    - master
+cache:
+  cargo: true
 before_script:
-    - pip install 'travis-cargo>=0.1.0,<0.2.0' --user
-    - pip install 'CppHeaderParser>=2.7.2,<3.0.0' --user
-    - travis-cargo --only nightly install clippy
+  - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
+  - bash cargo_install.sh cargo-prune;
+  - if [ "${TRAVIS_RUST_VERSION}" = "$RUST_STABLE" ]; then
+      bash cargo_install.sh rustfmt 0.9.0;
+    elif [ "${TRAVIS_OS_NAME}" = linux ]; then
+      bash cargo_install.sh clippy 0.0.186;
+    fi
 script:
-    - travis-cargo build
-    - ./on-nightly cargo clippy --lib
-    - ./on-nightly cargo clippy --bin cheddar
-    - travis-cargo test
-    - travis-cargo --only stable doc
-env:
-    global:
-        - RUST_BACKTRACE=1
-        - TRAVIS_CARGO_NIGHTLY_FEATURE=""
+  - if [ "${TRAVIS_RUST_VERSION}" = "$RUST_STABLE" ]; then
+      (
+        set -x;
+        cargo fmt -- --write-mode=diff &&
+        cargo test --release --verbose
+      );
+    elif [ "${TRAVIS_OS_NAME}" = linux ]; then
+      (
+        set -x;
+        cargo clippy && cargo clippy --profile=test
+      );
+    fi
+before_cache:
+- cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,12 @@ syntex_syntax = {version = "~0.58.1", optional = true}
 toml = "~0.3.2"
 clap = "~2.25.1"
 Inflector = "~0.11.1"
-jni = "~0.7.2"
+jni = "~0.8.1"
 quote = "~0.3.15"
+rustfmt = "~0.10.0"
+unwrap = "~1.1.0"
 
 [dev-dependencies]
-unwrap = "~1.1.0"
 colored = "~1.6.0"
 diff = "~0.1.11"
 indoc = "~0.2.3"

--- a/src/common.rs
+++ b/src/common.rs
@@ -60,7 +60,7 @@ pub fn append_output(text: String, file: &str, o: &mut Outputs) {
     }
 }
 
-/// Check the attribute is #[no_mangle].
+/// Check the attribute is `#[no_mangle]`.
 pub fn check_no_mangle(attr: &ast::Attribute) -> bool {
     match attr.value.node {
         ast::MetaItemKind::Word if attr.name() == "no_mangle" => true,
@@ -105,7 +105,7 @@ pub fn is_array_arg(arg: &ast::Arg, next_arg: Option<&ast::Arg>) -> bool {
 // TODO: Maybe it would be wise to use syntax::attr here.
 /// Loop through a list of attributes.
 ///
-/// Check that at least one attribute matches some criteria (usually #[repr(C)] or #[no_mangle])
+/// Check that at least one attribute matches some criteria (usually `#[repr(C)]` or `#[no_mangle]`)
 /// and optionally retrieve a String from it (usually a docstring).
 pub fn parse_attr<C, R>(attrs: &[ast::Attribute], check: C, retrieve: R) -> (bool, String)
 where

--- a/src/csharp/emit.rs
+++ b/src/csharp/emit.rs
@@ -86,7 +86,7 @@ pub fn emit_wrapper_function(
 
         if let Some(callback) = extract_callback(ty) {
             emit!(writer, "On");
-            emit_callback_wrapper_name(writer, &callback);
+            emit_callback_wrapper_name(writer, callback);
         } else {
             let name = param_name(name, index);
 
@@ -513,6 +513,7 @@ fn emit_struct_field(
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(explicit_counter_loop))]
 fn emit_wrapper_function_params(
     writer: &mut IndentedWriter,
     context: &Context,
@@ -546,6 +547,7 @@ fn emit_wrapper_function_params(
     }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(explicit_counter_loop))]
 fn emit_native_function_params(
     writer: &mut IndentedWriter,
     context: &Context,
@@ -560,7 +562,7 @@ fn emit_native_function_params(
         emit_marshal_as(writer, context, ty, Some(index), " ");
 
         if let Some(callback) = extract_callback(ty) {
-            emit_callback_wrapper_name(writer, &callback);
+            emit_callback_wrapper_name(writer, callback);
         } else {
             emit_type(writer, context, ty, Mode::ExternFunc);
         }
@@ -710,11 +712,10 @@ fn emit_type(writer: &mut IndentedWriter, context: &Context, ty: &Type, mode: Mo
     match *ty {
         Type::Unit => emit!(writer, "void"),
         Type::Bool => emit!(writer, "bool"),
-        Type::CChar => emit!(writer, "sbyte"),
+        Type::CChar | Type::I8 => emit!(writer, "sbyte"),
         Type::Char => emit!(writer, "char"),
         Type::F32 => emit!(writer, "float"),
         Type::F64 => emit!(writer, "double"),
-        Type::I8 => emit!(writer, "sbyte"),
         Type::I16 => emit!(writer, "short"),
         Type::I32 => emit!(writer, "int"),
         Type::I64 => emit!(writer, "long"),

--- a/src/csharp/intermediate.rs
+++ b/src/csharp/intermediate.rs
@@ -146,12 +146,10 @@ pub fn transform_function(decl: &ast::FnDecl) -> Option<Function> {
     loop {
         let one = if let Some(param) = carry.take() {
             Some(param)
+        } else if let Some(arg) = iter.next() {
+            Some(try_opt!(transform_function_param(arg)))
         } else {
-            if let Some(arg) = iter.next() {
-                Some(try_opt!(transform_function_param(arg)))
-            } else {
-                None
-            }
+            None
         };
 
         let two = if let Some(arg) = iter.next() {
@@ -303,7 +301,7 @@ fn transform_const_value(expr: &ast::Expr) -> Option<ConstValue> {
 fn transform_const_literal(lit: &ast::Lit) -> Option<ConstValue> {
     let result = match lit.node {
         ast::LitKind::Bool(value) => ConstValue::Bool(value),
-        ast::LitKind::Byte(value) => ConstValue::Int(value as i64),
+        ast::LitKind::Byte(value) => ConstValue::Int(i64::from(value)),
         ast::LitKind::Char(value) => ConstValue::Char(value),
         ast::LitKind::Int(value, _) => ConstValue::Int(value as i64),
         ast::LitKind::Float(ref value, _) |
@@ -362,7 +360,7 @@ fn transform_array(ty: &ast::Ty, size: &ast::Expr) -> Option<Type> {
     };
 
     let ty = match transform_type(ty) {
-        None => return None,
+        None |
         Some(Type::Array { .. }) => return None, // multi-dimensional array not supported yet
         Some(ty) => ty,
     };

--- a/src/csharp/tests.rs
+++ b/src/csharp/tests.rs
@@ -1200,7 +1200,7 @@ fn try_compile<T: Into<Option<LangCSharp>>>(
         .unwrap();
 
     let mut outputs = Outputs::default();
-    let mut lang = lang.into().unwrap_or_else(|| LangCSharp::new());
+    let mut lang = lang.into().unwrap_or_else(LangCSharp::new);
 
     parse::parse_mod(&mut lang, &ast.module, &mut outputs)?;
     lang.finalise_output(&mut outputs)?;

--- a/src/java/jni.rs
+++ b/src/java/jni.rs
@@ -382,7 +382,9 @@ fn generate_callback(cb: &ast::BareFnTy, context: &Context) -> JniCallback {
                 jni_cb_inputs.push(quote! { #len_arg_name: #len_arg_ty });
 
                 stmts.push(quote! {
-                    let #arg_name = jni_unwrap!(slice::from_raw_parts(#arg_name, #len_arg_name).to_java(&env));
+                    let #arg_name = jni_unwrap!(
+                        slice::from_raw_parts(#arg_name, #len_arg_name).to_java(&env)
+                    );
                 });
             } else {
                 // error: no length arg?
@@ -401,7 +403,8 @@ fn generate_callback(cb: &ast::BareFnTy, context: &Context) -> JniCallback {
                         // Strings
                         "c_char" => {
                             quote! {
-                                let #arg_name: JObject = jni_unwrap!(#arg_name.to_java(&env)).into();
+                                let #arg_name: JObject = jni_unwrap!(#arg_name.to_java(&env))
+                                    .into();
                             }
                         }
                         // Other ptrs

--- a/src/java/mod.rs
+++ b/src/java/mod.rs
@@ -80,9 +80,9 @@ impl LangJava {
     /// Adds package info to the NativeBindings Java module and indents lines
     fn format_native_functions(&self, funcs: &mut String) {
         // Indent lines
-        let lines = funcs.lines().fold(String::new(), |mut s, line| {
-            s.push_str(&format!("\t{}\n", line));
-            return s;
+        let lines = funcs.lines().fold(String::new(), |mut output, line| {
+            output.push_str(&format!("\t{}\n", line));
+            output
         });
         *funcs = format!(
             "package {namespace};\n\n
@@ -177,13 +177,13 @@ impl common::Lang for LangJava {
 
                 let fields = transform_struct_fields(variants.fields());
 
-                for field in fields.iter() {
+                for field in &fields {
                     let name = field.name().to_camel_case();
                     let struct_field = field.struct_field();
                     let mut ty = rust_to_java(&*struct_field.ty, &self.context)?
                         .unwrap_or_default();
 
-                    if let &StructField::Array { .. } = field {
+                    if let StructField::Array { .. } = *field {
                         // Detect array ptrs: skip the length args and add array to the type sig
                         ty.push_str("[]");
                     }
@@ -306,7 +306,7 @@ pub fn callback_name(inputs: &[ast::Arg], context: &Context) -> Result<String, E
             .map(struct_to_java_classname)
             .unwrap_or_default();
 
-        if is_array_arg(&arg, inputs.peek().cloned()) {
+        if is_array_arg(arg, inputs.peek().cloned()) {
             inputs.next();
             arg_type.push_str("ArrayLen");
         }
@@ -343,7 +343,7 @@ pub fn transform_native_fn(
         // Generate function arguments
         let mut java_type = rust_to_java(&arg.ty, context)?.unwrap_or_default();
 
-        if is_array_arg(&arg, fn_args.peek().cloned()) {
+        if is_array_arg(arg, fn_args.peek().cloned()) {
             // This is an array, so add it to the type description
             java_type.push_str("[]");
 
@@ -359,7 +359,7 @@ pub fn transform_native_fn(
             let cb_class = callback_name(&*bare_fn.decl.inputs, context)?;
             let cb_file = PathBuf::from(format!("{}.java", cb_class));
 
-            if let None = outputs.get(&cb_file) {
+            if outputs.get(&cb_file).is_none() {
                 eprintln!("Generating CB {}", cb_class);
 
                 let cb_output = transform_callback(&*arg.ty, &cb_class, context)?
@@ -474,7 +474,7 @@ fn callback_to_java(
         let arg_name = pprust::pat_to_string(&*arg.pat);
         let mut java_type = try_some!(rust_to_java(&*arg.ty, context));
 
-        if is_array_arg(&arg, args_iter.peek().cloned()) {
+        if is_array_arg(arg, args_iter.peek().cloned()) {
             // Detect array ptrs: skip the length args and add array to the type sig
             java_type.push_str("[]");
             args_iter.next();
@@ -581,7 +581,7 @@ fn anon_rust_to_java(
     }
 }
 
-/// Convert a Rust path type (my_mod::MyType) to a C type.
+/// Convert a Rust path type (`my_mod::MyType`) to a Java type.
 ///
 /// Types hidden behind modules are almost certainly custom types (which wouldn't work) except
 /// types in `libc` which we special case.
@@ -641,15 +641,10 @@ fn libc_ty_to_java(ty: &str) -> &str {
         "c_void" => "void",
         "c_float" => "float",
         "c_double" => "double",
-        "c_char" => "byte",
-        "c_schar" => "byte",
-        "c_uchar" => "byte",
-        "c_short" => "short",
-        "c_ushort" => "short",
-        "c_int" => "int",
-        "c_uint" => "int",
-        "c_long" => "long",
-        "c_ulong" => "long",
+        "c_char" | "c_schar" | "c_uchar" => "byte",
+        "c_short" | "c_ushort" => "short",
+        "c_int" | "c_uint" => "int",
+        "c_long" | "c_ulong" => "long",
         // All other types should map over to C or explicitly defined mapping.
         ty => ty,
     }
@@ -661,17 +656,12 @@ fn libc_ty_to_java(ty: &str) -> &str {
 fn osraw_ty_to_java(ty: &str) -> &str {
     match ty {
         "c_void" => "void",
-        "c_char" => "byte",
         "c_double" => "double",
         "c_float" => "float",
-        "c_int" => "int",
-        "c_long" => "long",
-        "c_schar" => "byte",
-        "c_short" => "short",
-        "c_uchar" => "byte",
-        "c_uint" => "int",
-        "c_ulong" => "long",
-        "c_ushort" => "short",
+        "c_char" | "c_schar" | "c_uchar" => "byte",
+        "c_int" | "c_uint" => "int",
+        "c_long" | "c_ulong" => "long",
+        "c_short" | "c_ushort" => "short",
         // All other types should map as-is
         ty => ty,
     }
@@ -690,8 +680,7 @@ fn rust_ty_to_java<'a>(ty: &'a str, context: &Context, use_type_map: bool) -> &'
         "u8" | "i8" => "byte",
         "u16" | "i16" => "short",
         "u32" | "i32" => "int",
-        "u64" | "i64" => "long",
-        "usize" | "isize" => "long",
+        "u64" | "i64" | "usize" | "isize" => "long",
         ty if use_type_map => {
             if let Some(mapping) = context.type_map.get(ty) {
                 mapping

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate toml;
 #[macro_use]
 extern crate quote;
 extern crate jni;
+extern crate rustfmt;
 
 #[cfg(test)]
 extern crate colored;
@@ -27,7 +28,6 @@ extern crate diff;
 #[cfg(test)]
 #[macro_use]
 extern crate indoc;
-#[cfg(test)]
 #[macro_use]
 extern crate unwrap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
           unknown_crate_types, warnings)]
-#![deny(deprecated, improper_ctypes, non_shorthand_field_patterns, overflowing_literals, plugin_as_library,
-        private_no_mangle_fns, private_no_mangle_statics, stable_features,
+#![deny(deprecated, improper_ctypes, non_shorthand_field_patterns, overflowing_literals,
+        plugin_as_library, private_no_mangle_fns, private_no_mangle_statics, stable_features,
         unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
         unused_attributes, unused_comparisons, unused_features, unused_parens, while_true)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -13,23 +13,20 @@ pub fn imported_mods(module: &ast::Mod) -> Vec<Vec<String>> {
         if let ast::Visibility::Inherited = item.vis {
             continue;
         }
-        match item.node {
-            ast::ItemKind::Use(ref import) => {
-                if let ast::ViewPathGlob(ref path) = import.node {
-                    let mut segments = path.segments.iter();
-                    if path.is_global() {
-                        segments.next();
-                    }
-                    let base_output_path: Vec<String> = segments
-                        .map(|seg| seg.identifier.name.as_str().to_string())
-                        .collect();
+        if let ast::ItemKind::Use(ref import) = item.node {
+            if let ast::ViewPathGlob(ref path) = import.node {
+                let mut segments = path.segments.iter();
+                if path.is_global() {
+                    segments.next();
+                }
+                let base_output_path: Vec<String> = segments
+                    .map(|seg| seg.identifier.name.as_str().to_string())
+                    .collect();
 
-                    if base_output_path[0] == "ffi" {
-                        imported.push(base_output_path);
-                    }
+                if base_output_path[0] == "ffi" {
+                    imported.push(base_output_path);
                 }
             }
-            _ => (),
         }
     }
 
@@ -63,11 +60,10 @@ pub fn parse_mod<L: Lang>(
             _ => Ok(()),
         };
 
-        match res {
-            // Display any non-fatal errors, fatal errors are handled at cause.
-            Err(error) => errors.push(error),
-            Ok(_) => {}  // Item should not be written to header.
-        };
+        // Display any non-fatal errors, fatal errors are handled at cause.
+        if let Err(error) = res {
+            errors.push(error)
+        }
     }
 
     if errors.is_empty() {

--- a/src/struct_field.rs
+++ b/src/struct_field.rs
@@ -20,10 +20,10 @@ pub enum StructField {
 impl StructField {
     pub fn struct_field(&self) -> &ast::StructField {
         match *self {
-            StructField::Primitive(ref f) => f,
-            StructField::Array { field: ref f, .. } => f,
-            StructField::StructPtr { field: ref f, .. } => f,
-            StructField::String(ref f) => f,
+            StructField::Primitive(ref f) |
+            StructField::Array { field: ref f, .. } |
+            StructField::StructPtr { field: ref f, .. } |
+            StructField::String(ref f) |
             StructField::LenField(ref f) => f,
         }
     }


### PR DESCRIPTION
Previously, Java exceptions caused Rust panics.
This PR fixes the issue and also integrates Clippy into the CI pipeline.