### PR TITLE
Version change to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [master]
 
+# [0.5.1] - 2018-06-26
+
+- Fix incorrectly generated C# delegates: they were garbage collected because of automatically
+  created and recycled references. Instead, we use static references now.
+- Change license to dual MIT/BSD.
+
 # [0.5.0] - 2018-06-14
 
 - Support multiple output languages.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_bindgen"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Sean Marshallsay <srm.1708@gmail.com>",
            "Matthew Gregan <kinetik@flim.org>",
            "MaidSafe Developers <dev@maidsafe.net>"]


### PR DESCRIPTION
- Fix incorrectly generated C# delegates: they were garbage collected because of automatically
  created and recycled references. Instead, we use static references now.
- Change license to dual MIT/BSD.