### PR TITLE
Version change to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [master]
 
+# [0.6.0] - 2018-08-10
+
+- Fix `illegal class name` error in Java/JNI
+- Fix `pub(crate)` items being parsed as a part of public API
+- Update `syntex_syntax` dependency to 0.59.0
+- Add more tests for the C language
+
 # [0.5.2] - 2018-07-03
 
 - Make generated C# delegates readonly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_bindgen"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Sean Marshallsay <srm.1708@gmail.com>",
            "Matthew Gregan <kinetik@flim.org>",
            "MaidSafe Developers <dev@maidsafe.net>"]


### PR DESCRIPTION
- Fix `illegal class name` error in Java/JNI
- Fix `pub(crate)` items being parsed as a part of public API
- Update `syntex_syntax` dependency to 0.59.0
- Add more tests for the C language