### PR TITLE
Allow to pass input code as a string [MAID-3142]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,13 @@ path = "src/bin/bindgen.rs"
 [dependencies]
 syntex_errors = {version = "~0.59.1", optional = true}
 syntex_syntax = {version = "~0.59.1", optional = true}
-toml = "~0.3.2"
+toml = "~0.4.6"
 clap = "~2.25.1"
-Inflector = "~0.11.1"
+Inflector = "~0.11.3"
 jni = "~0.10.1"
 quote = "~0.3.15"
 rustfmt = "~0.10.0"
-petgraph = "~0.4.12"
+petgraph = "~0.4.13"
 unwrap = "~1.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This change is required because currently we have no easy way of pulling external dependencies to parse their code. In particular, this is required by SAFE Client Libs because `ffi_utils` was split into its own repository. A simpler way of fixing this is to allow providing input code not only from external source files, but from static or dynamic strings as well. This is provided by the PR.