### PR TITLE
Filtering Java symbols

### DIFF
--- a/src/java/jni.rs
+++ b/src/java/jni.rs
@@ -475,10 +475,6 @@ fn generate_multi_jni_callback(
                         &[ #(#args),* ],
                     ));
                 }
-
-                if cbs.iter().any(|cb| cb.is_some()) {
-                    mem::forget(cbs);
-                }
             }
         }
     };


### PR DESCRIPTION
This PR provides two changes to fix https://github.com/maidsafe/safe_client_libs/issues/693:
* Filtering of Java symbols which can be used for manual reimplementation of certain
JNI functions in special cases, e.g. to have a longer lifetime for `disconnect_notifier`
* Deallocate all global refs in multi-callback functions. Previously we deallocated only the one callback (out of the many) that was called.