### PR TITLE
Version change to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [master]
 
+# [0.12.0] - 2019-04-12
+
+- Switch from a deprecated parsing library `syntex` to `syn`.
+- Fix inconsitencies and bugs in the C# module.
+- Add more tests for Java & JNI modules.
+- Use stable Rust (edition 2018).
+
 # [0.11.0] - 2018-11-15
 
 - Allow to filter symbols in Java bindgen. This can be used for manual reimplementation of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe_bindgen"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Sean Marshallsay <srm.1708@gmail.com>",
            "Matthew Gregan <kinetik@flim.org>",
            "MaidSafe Developers <dev@maidsafe.net>"]


### PR DESCRIPTION
 - Switch from a deprecated parsing library `syntex` to `syn`.
- Fix inconsitencies and bugs in the C# module.
- Add more tests for Java & JNI modules.
- Use stable Rust (edition 2018).