### PR TITLE
fix/parse: parse same modules only once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use csharp::LangCSharp;
 pub use errors::Level;
 pub use java::LangJava;
 pub use lang_c::LangC;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
 use std::fs;
 use std::fs::File;
@@ -253,12 +253,12 @@ impl Bindgen {
         let mut content = String::new();
         unwrap!(file.read_to_string(&mut content));
         let ast = unwrap!(syn::parse_file(&content));
-        let mut imported: Vec<Vec<String>> = Vec::new();
+        let mut imported: BTreeSet<Vec<String>> = Default::default();
         for item in ast.items {
             match &item {
                 syn::Item::Use(ref itemuse) => {
                     if parse::imported_mods(itemuse).is_some() {
-                        imported.push(unwrap!(parse::imported_mods(itemuse)));
+                        imported.insert(unwrap!(parse::imported_mods(itemuse)));
                     }
                 }
                 // Parsing const in lib.rs for CSharp

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -24,7 +24,6 @@ pub fn parse_usetree(usetree: &syn::UseTree) -> Vec<String> {
 
 /// Returns a list of FFI submodules imported in a top-level module
 pub fn imported_mods(import: &syn::ItemUse) -> Option<Vec<String>> {
-    //    let mut imported: Vec<Sti> = Vec::new();
     // If it's not visible it can't be called from C.
     if let syn::Visibility::Inherited = import.vis {
         None


### PR DESCRIPTION
If a module is imported multiple times in the source file, it was parsed multiple times by safe_bindgen before this fix.