### PR TITLE
fix/deps: fix clap version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ doc = false
 path = "src/bin/bindgen.rs"
 
 [dependencies]
-clap = "~2.25.0"
+clap = "~2.33.0"
 toml = "~0.5.0"
 Inflector = "~0.11.4"
 jni = "~0.12.0"


### PR DESCRIPTION
Fixes dependency issue for `safe_nd`.